### PR TITLE
Address to profile

### DIFF
--- a/app/api/common/entities.rb
+++ b/app/api/common/entities.rb
@@ -6,8 +6,18 @@ module Common
       expose :last_name
     end
 
+    class Address < Grape::Entity
+      expose :street_name
+      expose :city
+      expose :county
+      expose :postal_code
+      expose :coordinates
+      expose :details
+    end
+
     class Profile < User
       expose :email
+      expose :address, using: Address, expose_nil: true
     end
 
     class Need < Grape::Entity

--- a/app/api/common/helpers.rb
+++ b/app/api/common/helpers.rb
@@ -1,0 +1,19 @@
+module Common
+  module Helpers
+    extend Grape::API::Helpers
+
+    def permitted_params
+      @permitted_params ||= rename_keys!(
+        declared(params, include_missing: false, include_parent_namespaces: false)
+      )
+    end
+
+    private
+
+    def rename_keys!(params)
+      return params unless route.settings.key?(:aliases)
+
+      params.deep_transform_keys! { |key| route.settings[:aliases][key.to_sym] || key }
+    end
+  end
+end

--- a/app/api/common/profile_api.rb
+++ b/app/api/common/profile_api.rb
@@ -29,11 +29,21 @@ module Common
           optional :first_name, type: String, desc: 'First name', allow_blank: false
           optional :last_name, type: String, desc: 'Last name', allow_blank: false
           optional :email, type: String, desc: 'Email', allow_blank: false
+          optional :address, type: Hash do
+            optional :street_name, type: String, allow_blank: false
+            optional :city, type: String, allow_blank: false
+            optional :county, type: String, allow_blank: false
+            optional :postal_code, type: String, allow_blank: false
+            optional :coordinates, type: String, allow_blank: false
+            optional :details, type: String, allow_blank: false
+          end
         end
       end
+      route_setting :aliases, address: :address_attributes
+
       put do
         profile = current_user
-        profile.update!(params)
+        profile.update!(permitted_params)
         present profile, with: Entities::Profile
       end
     end

--- a/app/api/help_seekers/helpers.rb
+++ b/app/api/help_seekers/helpers.rb
@@ -1,6 +1,6 @@
 module HelpSeekers
   module Helpers
-    extend Grape::API::Helpers
+    include Common::Helpers
 
     def authorize_user_role!
       error!('Unauthorized', 401) unless current_user&.help_seeker?

--- a/app/api/volunteers/helpers.rb
+++ b/app/api/volunteers/helpers.rb
@@ -1,6 +1,6 @@
 module Volunteers
   module Helpers
-    extend Grape::API::Helpers
+    include Common::Helpers
 
     def authorize_user_role!
       error!('Unauthorized', 401) unless current_user&.volunteer?

--- a/app/api/volunteers/root_api.rb
+++ b/app/api/volunteers/root_api.rb
@@ -8,7 +8,7 @@ module Volunteers
       error!('Forbidden', 403)
     end
 
-    rescue_from Grape::Exceptions::ValidationErrors do |_e|
+    rescue_from Grape::Exceptions::ValidationErrors do
       error!('Bad request', 400)
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,13 +26,13 @@ class UsersController < ApplicationController
       :role,
       :password,
       :password_confirmation,
-      address_attributes: [
-        :street_name,
-        :city,
-        :county,
-        :postal_code,
-        :coordinates,
-        :details
+      address_attributes: %i[
+        street_name
+        city
+        county
+        postal_code
+        coordinates
+        details
       ]
     )
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,7 +26,14 @@ class UsersController < ApplicationController
       :role,
       :password,
       :password_confirmation,
-      :address_id
+      address_attributes: [
+        :street_name,
+        :city,
+        :county,
+        :postal_code,
+        :coordinates,
+        :details
+      ]
     )
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,5 +1,5 @@
 class Address < ApplicationRecord
-  has_one :user
+  belongs_to :user
 
   validates :street_name, presence: true
   validates :city, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   enum role: { help_seeker: 0, volunteer: 1, ngo: 2, admin: 3 }
 
-  belongs_to :address
+  has_one :address
 
   has_one :testimonial
 
@@ -19,6 +19,8 @@ class User < ApplicationRecord
 
   validates :phone_number, presence: true, uniqueness: true
   validates :first_name, presence: true
+
+  accepts_nested_attributes_for :address, update_only: true
 
   def self.from_token_request(request)
     User.find_by(phone_number: request.params[:auth][:phone_number])

--- a/db/migrate/20201110174722_add_user_id_to_address.rb
+++ b/db/migrate/20201110174722_add_user_id_to_address.rb
@@ -2,14 +2,16 @@ class AddUserIdToAddress < ActiveRecord::Migration[6.0]
   def up
     add_reference :addresses, :user
 
-    Address.find_each do |address|
-      address.update(user_id: address.user.id)
+    User.find_each do |user|
+      address = Address.find_by(id: user.address_id)
+      address.update!(user_id: user.id) if address
     end
   end
 
   def down
-    User.find_each do |user|
-      user.update(address_id: user.address.id)
+    Address.find_each do |address|
+      user = User.find_by(id: address.user_id)
+      user.update!(address_id: address.id) if user
     end
 
     remove_reference :addresses, :user

--- a/db/migrate/20201110174722_add_user_id_to_address.rb
+++ b/db/migrate/20201110174722_add_user_id_to_address.rb
@@ -1,0 +1,17 @@
+class AddUserIdToAddress < ActiveRecord::Migration[6.0]
+  def up
+    add_reference :addresses, :user
+
+    Address.find_each do |address|
+      address.update(user_id: address.user.id)
+    end
+  end
+
+  def down
+    User.find_each do |user|
+      user.update(address_id: user.address.id)
+    end
+
+    remove_reference :addresses, :user
+  end
+end

--- a/db/migrate/20201110204757_remove_address_id_from_users.rb
+++ b/db/migrate/20201110204757_remove_address_id_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveAddressIdFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :address_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_30_133109) do
+ActiveRecord::Schema.define(version: 2020_11_10_204757) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "street_name"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2020_10_30_133109) do
     t.string "coordinates"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 
   create_table "needs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
@@ -106,8 +108,6 @@ ActiveRecord::Schema.define(version: 2020_10_30_133109) do
     t.integer "role"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "address_id", null: false
-    t.index ["address_id"], name: "index_users_on_address_id"
   end
 
   add_foreign_key "needs", "users", column: "added_by_id"
@@ -120,5 +120,4 @@ ActiveRecord::Schema.define(version: 2020_10_30_133109) do
   add_foreign_key "testimonials", "users"
   add_foreign_key "user_special_cases", "special_cases"
   add_foreign_key "user_special_cases", "users"
-  add_foreign_key "users", "addresses"
 end

--- a/spec/factories/needs.rb
+++ b/spec/factories/needs.rb
@@ -2,8 +2,12 @@
 
 FactoryBot.define do
   factory :need do
-    added_by { FactoryBot.create(:user) }
-    chosen_by { FactoryBot.create(:user) }
+    added_by { FactoryBot.create(:user, :as_help_seeker) }
     description { Faker::Lorem.sentence }
+
+    trait :in_progress do
+      chosen_by { FactoryBot.create(:user, :as_volunteer) }
+      status { Need.statuses[:in_progress] }
+    end
   end
 end


### PR DESCRIPTION
- Change `has_one` relation between user and address - reverse direction
- Permit address's fields when a user is created
- Add Address entity
- Add permitted_params helper and update ProfileApi to accept address fields